### PR TITLE
The blank field test is performed twice on the owner field.

### DIFF
--- a/Stargazers/Stargazers/ViewControllers/ViewController.m
+++ b/Stargazers/Stargazers/ViewControllers/ViewController.m
@@ -49,7 +49,7 @@
 
     // check internet connection
     if ([self connected]) {
-        if ((self.txtOwner.text.length > 0) && (self.txtOwner.text.length > 0)) {
+        if ((self.txtOwner.text.length > 0) && (self.txtRepository.text.length > 0)) {
             
             // reset model
             [self.stargazerModel.stargazers removeAllObjects];


### PR DESCRIPTION
The bug is fixed. The blank field test is performed correctly on the owner field and the repository field.